### PR TITLE
Add fallback mock for numpy in profiler to handle ImportError

### DIFF
--- a/src/moe_debugger/profiler.py
+++ b/src/moe_debugger/profiler.py
@@ -11,7 +11,23 @@ import gc
 from typing import Dict, List, Optional, Any
 from collections import defaultdict, deque
 from contextlib import contextmanager
-import numpy as np
+
+# Try to import numpy, fall back to mock if not available
+try:
+    import numpy as np
+    NUMPY_AVAILABLE = True
+except ImportError:
+    # Mock numpy for basic operations
+    class MockNumpy:
+        @staticmethod
+        def mean(arr): return sum(arr) / len(arr) if arr else 0
+        @staticmethod  
+        def std(arr): return (sum((x - MockNumpy.mean(arr))**2 for x in arr) / len(arr))**0.5 if arr else 0
+        @staticmethod
+        def var(arr): return sum((x - MockNumpy.mean(arr))**2 for x in arr) / len(arr) if arr else 0
+    
+    np = MockNumpy()
+    NUMPY_AVAILABLE = False
 
 # Try to import torch, fall back to mock if not available
 try:


### PR DESCRIPTION
## Summary
- Adds a fallback mock implementation for numpy in `profiler.py` to handle cases where numpy is not installed
- Ensures basic statistical functions (`mean`, `std`, `var`) are available even without numpy
- Improves robustness of the profiler module by preventing import errors

## Changes

### Profiler Module
- Wrapped numpy import in try-except block
- Defined `MockNumpy` class with static methods for `mean`, `std`, and `var` calculations
- Assigned `np` to either real numpy or `MockNumpy` depending on availability
- Added `NUMPY_AVAILABLE` flag to indicate if numpy is installed

## Test plan
- Verified that profiler imports without error when numpy is installed
- Verified that profiler imports and basic numpy functions work using the mock when numpy is not installed
- Confirmed statistical calculations return expected results with mock implementation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/f798b678-f597-48f7-ad81-c268cea5b251